### PR TITLE
Bump json and activesupport to patched versions

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,10 +4,11 @@ source "https://rubygems.org"
 gem "jekyll", "~> 3.9"
 gem "github-pages", "~> 228"
 gem "webrick", "~> 1.7"
+gem "json", "~> 2.19.2"
+gem "activesupport", "~> 8.1.2.1"
 
 group :jekyll_plugins do
   gem 'jekyll-sitemap'
   gem 'jekyll-feed'
   gem 'jekyll-seo-tag'
 end
-

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 GEM
   remote: https://rubygems.org/
   specs:
-    activesupport (8.1.2)
+    activesupport (8.1.2.1)
       base64
       bigdecimal
       concurrent-ruby (~> 1.0, >= 1.3.1)
@@ -212,7 +212,7 @@ GEM
       gemoji (~> 3.0)
       html-pipeline (~> 2.2)
       jekyll (>= 3.0, < 5.0)
-    json (2.18.1)
+    json (2.19.2)
     kramdown (2.3.2)
       rexml
     kramdown-parser-gfm (1.1.0)
@@ -276,11 +276,13 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  activesupport (~> 8.1.2.1)
   github-pages (~> 228)
   jekyll (~> 3.9)
   jekyll-feed
   jekyll-seo-tag
   jekyll-sitemap
+  json (~> 2.19.2)
   webrick (~> 1.7)
 
 BUNDLED WITH


### PR DESCRIPTION
### Motivation
- Fix known security vulnerabilities in `json` (CVE-2026-33210) and `activesupport` (CVE-2026-33169/33170/33176) by upgrading to patched releases. 
- Ensure the upgrades are driven from the top-level `Gemfile` instead of only editing the lockfile so future `bundle` operations resolve correctly.

### Description
- Added explicit top-level constraints in `Gemfile` for `json` (`~> 2.19.2`) and `activesupport` (`~> 8.1.2.1`).
- Updated `Gemfile.lock` to reflect the resolved patched versions `json (2.19.2)` and `activesupport (8.1.2.1)` and added them to the lockfile `DEPENDENCIES` list.
- No other code or configuration changes were made.

### Testing
- Attempted `bundle update activesupport json`, but the operation failed due to a Rubygems HTTP 403 error in this environment so dependencies could not be fetched. 
- Ran `bundle check`, which parsed the lockfile successfully and reported the expected list of missing gems since gems were not installed locally in this environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c259bcc0cc83248e61d1602d0ffeb7)